### PR TITLE
Fixed problem with non-static ramp

### DIFF
--- a/Gazebo Models/ramp/model.sdf
+++ b/Gazebo Models/ramp/model.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
   <model name="Ramp">
-    <!-- <static>true</static> -->
+    <static>true</static>
     <link name="link">
       <inertial>
       <pose>0 0 0.0175 0 0 0</pose>


### PR DESCRIPTION
Changed the ramp to be static, that way it doesn't move when heavy objects interact with it.